### PR TITLE
Handle slow/nil Graphite metrics

### DIFF
--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -50,7 +50,7 @@ class Metric < ActiveRecord::Base
 
   private
     def latest_datapoint
-      return datapoints[-2].first if graphite_metric?
+      return datapoints.map { |point| point unless point.first.nil? }.compact.last.first if graphite_metric?
       datapoints.last.first
     end
 

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Metric, :type => :model do
           [2534, 20],
           [312, 30],
           [13, 40],
-          [0, 50]
+          [nil, 50]
         ])
         allow(GraphiteMetric).to receive(:new).and_return(lib)
       }


### PR DESCRIPTION
Sometimes graphite is slow and will return null as the datapoint value
for a given timestamp because either the true value is null or it is
being buffered in the carbon cache and hasn't been written yet. By mapping
the array values and restricting ourselves to actual real values we can
obtain a much better alarm state and prevent an error